### PR TITLE
feat(frontend): Prettier 導入と ESLint 統合 (Phase A)

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+package-lock.json

--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "arrowParens": "always"
+}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -3,6 +3,7 @@ import globals from 'globals'
 import react from 'eslint-plugin-react'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import prettier from 'eslint-config-prettier'
 
 export default [
   { ignores: ['dist'] },
@@ -35,4 +36,5 @@ export default [
       ],
     },
   },
+  prettier,
 ]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,10 +18,12 @@
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
         "eslint": "^9.17.0",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.2",
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.16",
         "globals": "^15.14.0",
+        "prettier": "^3.8.3",
         "vite": "^6.0.5"
       }
     },
@@ -2269,6 +2271,22 @@
         }
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.4",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.4.tgz",
@@ -3715,6 +3733,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -20,10 +22,12 @@
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^9.17.0",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.14.0",
+    "prettier": "^3.8.3",
     "vite": "^6.0.5"
   }
 }


### PR DESCRIPTION
## Summary

Phase A の Lint/Format 統一タスクの一環。フロントエンドに Prettier を導入し、ESLint と統合する。

Refs #3

## 変更内容

- `prettier`, `eslint-config-prettier` を devDependencies に追加
- `frontend/.prettierrc.json` / `frontend/.prettierignore` を新規作成
  - 2 space / single quote / width 100 / trailing comma (es5) / semicolon 有り
- `eslint.config.js` の末尾に `prettier` を追加し、ESLint と Prettier の
  フォーマット系ルール競合を解消
- `package.json` に `format` / `format:check` スクリプトを追加

## スコープ外（後続 PR に分離）

既存コードの一括フォーマット（`npm run format` 相当）は本 PR に含まない。
`npm run format:check` で **26 ファイルに style issues** があることは確認済み。
これらの reformat は差分が大きくなるため、**ツール導入 PR とレビューしやすく分離** する意図。

## Test plan

- [x] `npm install` 成功
- [x] `npm run lint` 実行可能（既存 45 エラーは ESLint の既存コード由来、Prettier 競合ではない）
- [x] `npm run format:check` が機能（現在 26 ファイルに差分検出）
- [ ] レビュアー確認: `cd frontend && npm ci && npm run lint && npm run format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)