### PR TITLE
fix(migrations): SwotHistory の欠落 migration を追加

### DIFF
--- a/src/app/migrations/0014_swothistory.py
+++ b/src/app/migrations/0014_swothistory.py
@@ -1,0 +1,24 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('app', '0013_swotanalysis_project'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SwotHistory',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('changed_at', models.DateTimeField(auto_now_add=True)),
+                ('change_summary', models.TextField(blank=True, null=True)),
+                ('swot', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='history', to='app.swotanalysis')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/src/app/migrations/0014_swothistory.py
+++ b/src/app/migrations/0014_swothistory.py
@@ -1,3 +1,6 @@
+# Manually added for Django 4.2.7 on 2026-04-19
+# models.py の SwotHistory モデルに対応する migration が欠落していたため手動で補完。
+
 import django.db.models.deletion
 from django.conf import settings
 from django.db import migrations, models


### PR DESCRIPTION
## Summary

`src/app/models.py` に定義されている `SwotHistory` モデルに対応する migration が
抜けていたため追加。pytest 導入作業中に `no such table: app_swothistory` で発覚。

## 背景

- `SwotHistory` モデル自体は `models.py:121` に定義済み（SWOT の変更履歴を記録する用途）
- 対応する CreateModel migration が `src/app/migrations/` に存在しなかった
- 本番では該当モデルを通る導線が未整備のため、実害は顕在化していなかった
- テスト環境で pytest-django が `serialize_db_to_string` を呼ぶ際、
  存在しないテーブルへのクエリで `OperationalError` が発生

## 変更内容

`src/app/migrations/0014_swothistory.py` を追加:

- `CreateModel` SwotHistory
- 依存: `0013_swotanalysis_project` + `AUTH_USER_MODEL`
- フィールド: `id` (BigAutoField, `settings.DEFAULT_AUTO_FIELD` に合わせる)、
  `swot` (FK→SWOTAnalysis, CASCADE, related_name='history')、
  `user` (FK→User, CASCADE)、`changed_at` (DateTimeField auto_now_add)、
  `change_summary` (TextField nullable/blank)

## 安全性

- 新規テーブル作成のみ（既存データへの影響なし）
- `python manage.py makemigrations --check --dry-run` で "No changes detected" (exit 0) を確認
- 本番環境でも `migrate` 一発で追加される

## Test plan

- [x] `makemigrations --check` で差分なし
- [ ] ローカル SQLite で `migrate` が通る
- [ ] Heroku stg/prod で `heroku run python manage.py migrate`

Refs #3 (Phase A)、#5 (pytest PR の前提)

🤖 Generated with [Claude Code](https://claude.com/claude-code)