### PR TITLE
docs: README テストセクションを Vitest 導入後の実態に合わせる

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ redis-server
 pip install -r requirements-dev.txt
 pytest
 
-# Frontend（後続 PR で vitest 導入予定）
+# Frontend（vitest）
+cd frontend && npm test
+
+# Frontend Lint / Format
 cd frontend && npm run lint
 cd frontend && npm run format:check
 ```


### PR DESCRIPTION
## Summary

PR #11 マージ時に入れた「後続 PR で vitest 導入予定」という仮記述を、
PR #12（Vitest 導入）マージ後の実態に置き換える小さな cleanup PR。

## 変更内容

- README.md のテストセクション
  - `# Frontend（後続 PR で vitest 導入予定）` → `# Frontend（vitest）`
  - `cd frontend && npm test` コマンドを追加
  - Lint/Format は別行に分離

## 背景

PR #11 と PR #12 を互いに README 競合を避けるため分離した副作用で、
#11 の README セクションが暫定的な記述のまま残っていた。Phase A が完了した
タイミングで清算する。

Closes #3 (Phase A 完了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)