### PR TITLE
refactor(models): 旧 SWOT / SwotIdeas モデル（デッドコード）削除 (Phase B)

### DIFF
--- a/src/app/migrations/0015_delete_swot_swotideas.py
+++ b/src/app/migrations/0015_delete_swot_swotideas.py
@@ -1,0 +1,24 @@
+# Manually added for Django 4.2.7 on 2026-04-19
+# 旧 SWOT / SwotIdeas モデル（デッドコード）を削除する migration。
+# 新 SWOTAnalysis / SWOTItem 系統にフル移行済みで、
+# views / serializers / consumers / frontend いずれからも参照されていないことを
+# grep で確認した上で削除。
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('app', '0014_swothistory'),
+    ]
+
+    operations = [
+        # SwotIdeas は SWOT への FK を持つので先に削除する
+        migrations.DeleteModel(
+            name='SwotIdeas',
+        ),
+        migrations.DeleteModel(
+            name='SWOT',
+        ),
+    ]

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -11,20 +11,6 @@ class UserProfile(models.Model):
     # 他に必要なフィールドがあれば追加します
 
 
-class SWOT(models.Model):
-    title = models.CharField(max_length=100)
-
-class SwotIdeas(models.Model):
-    swot = models.ForeignKey(SWOT, on_delete=models.CASCADE)
-    category_choices = (
-        ('Strength', 'Strength'),
-        ('Weakness', "Weakness"),
-        ('Opportunity', 'Opportunity'),
-        ('Threat', 'Threat'),
-    )
-    category = models.CharField(max_length=20, choices=category_choices)
-    content = models.CharField(max_length=300)
-
 class FourPAnalysis(models.Model):
     overview = models.TextField(verbose_name="概要", blank=True)       # 追加例
     memo = models.TextField(verbose_name="プロジェクトメモ", blank=True)  # 追加例


### PR DESCRIPTION
## Summary

Phase B の第一弾。SWOT 系モデルの重複整理として、**利用されていない旧系統**（`SWOT` / `SwotIdeas`）を削除する。

Refs #4

## 調査結果

調査により、**旧 SWOT / SwotIdeas は完全なデッドコード**と判明。以下で一切参照されていなかった：

| 層 | 参照箇所 |
|---|---|
| `src/app/views.py` | なし |
| `src/app/serializers.py` | なし |
| `src/app/consumers/` | なし（共同編集は `SWOTAnalysis.id` ベース） |
| `src/app/urls.py` / `src/config/urls.py` | なし |
| `frontend/src/**/*.jsx` | なし（API は `swot-analysis`, `personal-swot`, `projects/.../swot/` のみ） |
| migrations | 追加変更なし（2025-02 以降の alter migration なし） |

2025-02 以降は新 `SWOTAnalysis` / `SWOTItem` + `CrossSWOT` / `SwotHistory` 系統に
フル移行済み。

## 変更内容

- `src/app/models.py`: `class SWOT` / `class SwotIdeas` を削除
- `src/app/migrations/0015_delete_swot_swotideas.py`: DeleteModel migration を手動作成
  - FK 依存のため `SwotIdeas` を先に削除、次に `SWOT`

## データへの影響

- 新系統の `SWOTAnalysis` / `SWOTItem` / `CrossSWOT` / `SwotHistory` には影響なし
- 旧 `app_swot` / `app_swotideas` テーブルに**本番データがあれば消失**する
- 本番ではどの view/consumer からもこれらテーブルへ書き込みが走らないため、
  データがあっても過去の仮実装テスト用の残骸のはず

## 検証

- [x] `python manage.py makemigrations --check --dry-run`: "No changes detected" (exit 0)
- [x] `python manage.py check`: "System check identified no issues"
- [x] `pytest`: 3 passed
- [ ] **ローカル動作確認**: `docker-compose up` で起動 → SWOT 共同編集・作成画面が従来通り動くこと
- [ ] Heroku stg/prod で `heroku run python manage.py migrate` を実行

## 次の Phase B ステップ（本 PR の後）

- `SwotHistory` は migration 済みだが書き込み箇所がまだない。SWOT 更新時に
  履歴を記録する実装を追加する小さな PR を出す案あり（任意）
- Phase B 全体はこれで実質完了（当初想定していた「三段階パターン練習」は、
  デッドコード削除で済んだため不要になった）

🤖 Generated with [Claude Code](https://claude.com/claude-code)