### PR TITLE
fix: Issue #16 バグ1 — roomId undefined による 500/WS 失敗を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ src/staticfiles/
 # IDE/エディタ関連
 .idea/
 *.swp
+
+# Playwright MCP artifacts
+.playwright-mcp/

--- a/frontend/src/pages/ProjectDetail.jsx
+++ b/frontend/src/pages/ProjectDetail.jsx
@@ -11,6 +11,7 @@ function ProjectDetail() {
   const { id } = useParams();   // ルートパラメータからidを取得
   const [project, setProject] = useState(null);
   const [csrfToken, setCsrfToken] = useState(null);
+  const [fetchError, setFetchError] = useState(null);
   
     // CSRFトークンをバックエンドの /api/csrf/ エンドポイントから取得
     useEffect(() => {
@@ -34,20 +35,37 @@ function ProjectDetail() {
     }, []);
 
   useEffect(() => {
-    // 例: Django REST Frameworkのエンドポイントが /api/projects/:id の場合
+    setFetchError(null);
+    setProject(null);
     fetch(`${API_BASE}/api/projects/${id}/`, {
       method: 'GET',
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
-        'X-CSRFToken': csrfToken,
       }
     })
-      .then(response => response.json())
-      .then(data => setProject(data))
-      .catch(error => console.error('Error fetching project:', error));
+      .then(async response => {
+        if (!response.ok) {
+          setFetchError({ status: response.status });
+          return;
+        }
+        const data = await response.json();
+        setProject(data);
+      })
+      .catch(error => {
+        console.error('Error fetching project:', error);
+        setFetchError({ message: error.message });
+      });
   }, [id]);
 
+  if (fetchError) {
+    return (
+      <p>
+        プロジェクトを読み込めませんでした
+        {fetchError.status ? `（HTTP ${fetchError.status}）` : ''}
+      </p>
+    );
+  }
   if (!project?.id) {
     return <p>Loading...</p>;
   }

--- a/frontend/src/pages/ProjectDetail.jsx
+++ b/frontend/src/pages/ProjectDetail.jsx
@@ -48,7 +48,7 @@ function ProjectDetail() {
       .catch(error => console.error('Error fetching project:', error));
   }, [id]);
 
-  if (!project) {
+  if (!project?.id) {
     return <p>Loading...</p>;
   }
 

--- a/frontend/src/pages/projects/ChatComponent.jsx
+++ b/frontend/src/pages/projects/ChatComponent.jsx
@@ -15,9 +15,12 @@ function ChatComponent({ roomId }) {
   // チャット履歴のロード
   useEffect(() => {
     if (!roomId) {
+      setMessages([]);
       setLoadingHistory(false);
       return;
     }
+    setLoadingHistory(true);
+    setMessages([]);
     console.log("Fetching chat history, current user:", user);
     async function fetchChatHistory() {
       try {

--- a/frontend/src/pages/projects/ChatComponent.jsx
+++ b/frontend/src/pages/projects/ChatComponent.jsx
@@ -14,6 +14,10 @@ function ChatComponent({ roomId }) {
 
   // チャット履歴のロード
   useEffect(() => {
+    if (!roomId) {
+      setLoadingHistory(false);
+      return;
+    }
     console.log("Fetching chat history, current user:", user);
     async function fetchChatHistory() {
       try {
@@ -38,6 +42,7 @@ function ChatComponent({ roomId }) {
 
   // WebSocket 接続の処理
   useEffect(() => {
+    if (!roomId) return;
     const wsUrl = import.meta.env.VITE_WS_URL;
     const newSocket = new WebSocket(`${wsUrl}/ws/chat/${roomId}/`);
     setSocket(newSocket);

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -166,7 +166,7 @@ def get_chat_messages(request, room_id):
     """
     try:
         room = ChatRoom.objects.get(id=room_id)
-    except ChatRoom.DoesNotExist:
+    except (ChatRoom.DoesNotExist, ValueError):
         return Response({"detail": "Chat room not found."}, status=status.HTTP_404_NOT_FOUND)
 
     # メッセージをタイムスタンプ順に取得（古い順に並べる）


### PR DESCRIPTION
## Summary
- Issue #16 バグ 1 を修正
- `ProjectDetail` が `/api/projects/<id>/` の 404 レスポンス body をそのまま `project` state に入れ、`project.id = undefined` のまま `ChatComponent` がマウントされていた
- 結果として `/api/chat/undefined/messages/` が 500 (`ValueError: Field 'id' expected a number but got 'undefined'`)、WebSocket も `ws://.../ws/chat/undefined/` に接続失敗
- フロント側ガード + バックエンドの例外 catch 拡張で多段防御

## 変更点
- `frontend/src/pages/projects/ChatComponent.jsx`: fetch / WebSocket 双方の useEffect 冒頭で `if (!roomId) return;`
- `frontend/src/pages/ProjectDetail.jsx`: `if (!project?.id)` で loading 表示を維持
- `src/app/views.py`: `get_chat_messages` で `ValueError` も `DoesNotExist` 同様 404 にまとめる
- `.gitignore`: Playwright MCP 作業ディレクトリを除外

## 再現と検証
Playwright MCP でログイン後に `/projects/999`（存在しない project）を開く手順で再現/検証。

| | Before | After |
|---|---|---|
| `GET /api/chat/undefined/messages/` | 500 ValueError | そもそも発火しない |
| `GET /api/chat/undefined/messages/` を直接叩く | 500 | 404 `{detail:"Chat room not found."}` |
| 正常 project 閲覧 | OK | OK（regression なし） |

## Test plan
- [x] pytest: 11 passed (`DJANGO_SETTINGS_MODULE=config.settings_test`)
- [x] vitest: 2 passed
- [x] Playwright MCP で `/projects/999` を開き、`/api/chat/undefined/messages/` が飛ばないことを network log で確認
- [x] 正常 project (`/projects/1`) の描画に regression がないことを確認

## 備考
- Issue #16 のバグ 2（`invite-member` 404）は実測では再現せず、ルーティングは正常動作。別 Issue/コメントで整理予定。

Closes part of #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)