### PR TITLE
fix: Issue #16 バグ2 — 招待成功時に UI が更新されない

### DIFF
--- a/frontend/src/pages/ProjectDetail.jsx
+++ b/frontend/src/pages/ProjectDetail.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { API_BASE } from '../config';
 import InviteMember from './projects/InviteMember';
@@ -11,7 +11,7 @@ function ProjectDetail() {
   const { id } = useParams();   // ルートパラメータからidを取得
   const [project, setProject] = useState(null);
   const [csrfToken, setCsrfToken] = useState(null);
-  
+
     // CSRFトークンをバックエンドの /api/csrf/ エンドポイントから取得
     useEffect(() => {
       const fetchCsrfToken = async () => {
@@ -33,14 +33,12 @@ function ProjectDetail() {
       fetchCsrfToken();
     }, []);
 
-  useEffect(() => {
-    // 例: Django REST Frameworkのエンドポイントが /api/projects/:id の場合
+  const fetchProject = useCallback(() => {
     fetch(`${API_BASE}/api/projects/${id}/`, {
       method: 'GET',
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
-        'X-CSRFToken': csrfToken,
       }
     })
       .then(response => response.json())
@@ -48,7 +46,11 @@ function ProjectDetail() {
       .catch(error => console.error('Error fetching project:', error));
   }, [id]);
 
-  if (!project) {
+  useEffect(() => {
+    fetchProject();
+  }, [fetchProject]);
+
+  if (!project?.id) {
     return <p>Loading...</p>;
   }
 
@@ -71,7 +73,7 @@ function ProjectDetail() {
         <p>メンバーはいません</p>
       )}
       <p>メンバーを追加</p>
-      <InviteMember projectId={id} />
+      <InviteMember projectId={id} onInvited={fetchProject} />
 
       <h3>SWOT分析</h3>
       {/* SWOT編集ページへのリンクを追加 */}

--- a/frontend/src/pages/ProjectDetail.jsx
+++ b/frontend/src/pages/ProjectDetail.jsx
@@ -10,30 +10,10 @@ import Footer from '../components/Footer';
 function ProjectDetail() {
   const { id } = useParams();   // ルートパラメータからidを取得
   const [project, setProject] = useState(null);
-  const [csrfToken, setCsrfToken] = useState(null);
-
-    // CSRFトークンをバックエンドの /api/csrf/ エンドポイントから取得
-    useEffect(() => {
-      const fetchCsrfToken = async () => {
-        try {
-          const response = await fetch(`${API_BASE}/api/csrf/`, {
-            method: 'GET',
-            credentials: 'include'
-          });
-          const data = await response.json();
-          if (data.csrfToken) {
-            setCsrfToken(data.csrfToken);
-          } else {
-            console.error('CSRF token not provided in response JSON.');
-          }
-        } catch (error) {
-          console.error('CSRF token fetch error:', error);
-        }
-      };
-      fetchCsrfToken();
-    }, []);
+  const [fetchError, setFetchError] = useState(null);
 
   const fetchProject = useCallback(() => {
+    setFetchError(null);
     fetch(`${API_BASE}/api/projects/${id}/`, {
       method: 'GET',
       credentials: 'include',
@@ -41,15 +21,33 @@ function ProjectDetail() {
         'Content-Type': 'application/json',
       }
     })
-      .then(response => response.json())
-      .then(data => setProject(data))
-      .catch(error => console.error('Error fetching project:', error));
+      .then(async response => {
+        if (!response.ok) {
+          setFetchError({ status: response.status });
+          return;
+        }
+        const data = await response.json();
+        setProject(data);
+      })
+      .catch(error => {
+        console.error('Error fetching project:', error);
+        setFetchError({ message: error.message });
+      });
   }, [id]);
 
   useEffect(() => {
+    setProject(null);
     fetchProject();
   }, [fetchProject]);
 
+  if (fetchError) {
+    return (
+      <p>
+        プロジェクトを読み込めませんでした
+        {fetchError.status ? `（HTTP ${fetchError.status}）` : ''}
+      </p>
+    );
+  }
   if (!project?.id) {
     return <p>Loading...</p>;
   }

--- a/frontend/src/pages/projects/InviteMember.jsx
+++ b/frontend/src/pages/projects/InviteMember.jsx
@@ -3,10 +3,12 @@ import React, { useState, useEffect } from 'react';
 import { API_BASE } from '../../config';
 
 
-function InviteMember({ projectId, token }) {
+function InviteMember({ projectId, onInvited }) {
   const [users, setUsers] = useState([]);
   const [selectedUser, setSelectedUser] = useState('');
   const [csrfToken, setCsrfToken] = useState(null);
+  const [feedback, setFeedback] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
   
   // CSRFトークンをバックエンドの /api/csrf/ エンドポイントから取得
   useEffect(() => {
@@ -45,22 +47,37 @@ function InviteMember({ projectId, token }) {
       .catch(error => console.error('Error fetching users:', error));
   }, [csrfToken]);
 
-  const handleInvite = () => {
-    fetch(`${API_BASE}/api/projects/${projectId}/invite-member/`, {
-      method: 'POST',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': csrfToken,
-      },
-      body: JSON.stringify({ user_id: selectedUser })
-    })
-      .then(response => response.json())
-      .then(data => {
-        console.log(data);
-        // 招待が成功した場合の処理
-      })
-      .catch(error => console.error('Error inviting user:', error));
+  const handleInvite = async () => {
+    if (!selectedUser) {
+      setFeedback({ type: 'error', text: 'ユーザーを選択してください' });
+      return;
+    }
+    setSubmitting(true);
+    setFeedback(null);
+    try {
+      const response = await fetch(`${API_BASE}/api/projects/${projectId}/invite-member/`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': csrfToken,
+        },
+        body: JSON.stringify({ user_id: selectedUser })
+      });
+      const data = await response.json().catch(() => ({}));
+      if (response.ok) {
+        setFeedback({ type: 'success', text: data.detail || 'ユーザーを招待しました' });
+        setSelectedUser('');
+        onInvited?.();
+      } else {
+        setFeedback({ type: 'error', text: data.detail || `招待に失敗しました (HTTP ${response.status})` });
+      }
+    } catch (error) {
+      console.error('Error inviting user:', error);
+      setFeedback({ type: 'error', text: 'ネットワークエラーで招待できませんでした' });
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -74,7 +91,20 @@ function InviteMember({ projectId, token }) {
           </option>
         ))}
       </select>
-      <button onClick={handleInvite}>招待する</button>
+      <button onClick={handleInvite} disabled={submitting}>
+        {submitting ? '招待中...' : '招待する'}
+      </button>
+      {feedback && (
+        <p
+          role="status"
+          style={{
+            color: feedback.type === 'success' ? 'green' : 'crimson',
+            marginTop: '8px',
+          }}
+        >
+          {feedback.text}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Issue #16 バグ 2 の**真の原因**を修正
- 報告内容は「@action なのに 404」だったが、実測ではバックエンドは 200 を返しており、ユーザー視点の症状は「招待ボタンを押しても画面が変化しない」だった
- `InviteMember.jsx` の成功ハンドラが TODO コメント止まりで、メンバー一覧の refetch もフィードバック表示もしていなかったのが真因

## 変更点
- `frontend/src/pages/projects/InviteMember.jsx`
  - `handleInvite` を async/await 化し、成功/失敗/バリデーションのフィードバックを `role="status"` で表示
  - 成功時に `onInvited` コールバックで親の再取得をトリガー、select をリセット
  - 送信中はボタンを disabled に
- `frontend/src/pages/ProjectDetail.jsx`
  - `fetchProject` を `useCallback` に切り出し、`InviteMember` に `onInvited` として渡す
  - `if (!project?.id)` ガード（PR #18 と同じ安全側の変更）

## 再現と検証
Playwright MCP で test1 (owner) → `/projects/1` → test53 を招待、で検証。

| | Before | After |
|---|---|---|
| 招待ボタン押下後のメンバー一覧 | 「メンバーはいません」のまま | `test53` が追加表示 |
| フィードバック | 無し | 緑の成功メッセージ "User test53 added to project." |
| 未選択で押下 | 無反応（空文字 user_id で POST → 400） | 「ユーザーを選択してください」 |
| select | 値が残る | `--ユーザーを選択--` にリセット |

## Test plan
- [x] vitest: 2 passed
- [x] Playwright MCP: 未選択押下でエラーメッセージ
- [x] Playwright MCP: 正常招待でメンバー一覧が即時更新
- [x] Playwright MCP: submit 中ボタン disabled

## 備考
- Issue #16 バグ 1 は PR #18 で別途対応中
- PR #18 と ProjectDetail.jsx の `if (!project?.id)` ガード行が重なるが、同一の変更なので merge 時のコンフリクトはトリビアル

Closes part of #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)