### PR TITLE
chore: adopt platform-standards via psctl

### DIFF
--- a/.claude/project.json
+++ b/.claude/project.json
@@ -1,0 +1,3 @@
+{
+  "lane": "prj-django-project"
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,22 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "psctl status --brief --if-outdated"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "task-board-sync || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/gcal-event-register/SKILL.md
+++ b/.claude/skills/gcal-event-register/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: gcal-event-register
+description: プロジェクトの作業枠とマイルストーンを Google Calendar に標準化された形で登録する。グローバル CLAUDE.md の命名体系（prj-* / oss-* / role-* / study-* / life-* / fin-*）に対応するカレンダーへ書き込み、終業時に予定→実績の差分を反映する。MCP google-calendar 経由。
+---
+
+# gcal-event-register
+
+プロジェクト → Google Calendar への書き込みを共通化するスキル（プレイブック型）。
+実体コードはない。Claude Code セッション内で MCP `google-calendar` を呼び出す際のお作法を定義する。
+
+## 目的
+
+- 各プロジェクトの「作業枠」「マイルストーン」が、対応カレンダーに統一フォーマットで載っている状態を保つ
+- ユーザーが GCal を見たときに、何が走っていて何が完了したかが一目で把握できる
+- 終業時に「予定 vs 実績」の差分が見える状態を作る
+
+## カレンダー命名の対応
+
+カレンダー名 = レーン名 = グローバル CLAUDE.md の命名体系（`~/.claude/CLAUDE.md` 参照）。
+
+| グループ | 例 |
+|---|---|
+| `prj-*` | `prj-django-project`, `prj-vue-chat` |
+| `oss-*` | `oss-cmux`, `oss-projen`, `oss-aws-cdk` |
+| `role-*` / `study-*` | `role-shindan`, `study-data` |
+| `life-*` / `fin-*` | `life-housing`, `fin-budget` |
+
+**プロジェクト名 → カレンダー名は 1:1 対応**。新規プロジェクトを始める前に、対応カレンダーが GCal 上に存在することを `mcp__google-calendar__list-calendars` で確認する。
+
+## 標準動作
+
+### 1. 作業開始時：当日の作業枠を登録
+
+```
+mcp__google-calendar__create-event
+  calendarId:  <prj-xxx>
+  summary:     <タイトル一行サマリ>
+  description: |
+    link: <Issue/PR URL or no-git>
+    done-when: <完了条件>
+    tag: #<lane-name>
+  start:  <YYYY-MM-DDTHH:MM:SS+09:00>
+  end:    <YYYY-MM-DDTHH:MM:SS+09:00>
+```
+
+- start / end は JST。タイムゾーンを必ず付ける
+- `description` 内の link / done-when は **task-board-sync のカードと同じフィールド** を使う。看板と GCal で同じ語彙を保つ
+
+### 2. ミッション・マイルストーン：終日イベントで登録
+
+```
+mcp__google-calendar__create-event
+  calendarId:  <prj-xxx>
+  summary:     [MS] <マイルストーン名>
+  description: |
+    done-when: <完了条件>
+    link: <該当 Issue or no-git>
+  start:    <YYYY-MM-DD>          # 終日イベント
+  end:      <YYYY-MM-DD>
+```
+
+- 終日イベントは date 形式（`YYYY-MM-DD`）。dateTime ではない
+- summary 先頭の `[MS]` プレフィックスでマイルストーンと作業枠を視覚的に区別
+
+### 3. 完了時：実績更新と Slack 報告
+
+完了時のアクション 3 点セット：
+
+1. GCal の予定を **実績として更新**（`mcp__google-calendar__update-event`）
+   - `summary` 末尾に `[done]` を付加
+   - `description` の末尾に `actual: Xh` を追記
+2. task-board-sync で看板上のカードを `[x]` に更新
+3. `notify-slack` skill で対応 Slack チャンネルに完了報告
+
+```bash
+source .claude/skills/notify-slack/notify.sh
+notify_slack "<@U08RPS2BLUD> ✅ <タイトル> done. link: <URL>" "$SLACK_CHANNEL_ID"
+```
+
+## カレンダーが存在しない場合
+
+新規プロジェクトを開始する際、対応カレンダーが未作成のことがある。その場合：
+
+1. `mcp__google-calendar__list-calendars` で確認
+2. 無ければ「カレンダー `<prj-xxx>` を新規作成しますか？」とユーザーに確認
+3. 承認後に新規作成（GCal 側 UI で作成 or MCP 経由）
+
+エージェントが勝手にカレンダーを作らないこと。
+
+## トリガー（自走の設計）
+
+| タイミング | 動作 |
+|---|---|
+| 作業開始（セッション内で「これから X する」と宣言された時） | 作業枠を当日に登録 |
+| マイルストーン宣言時 | 終日イベントとして登録 |
+| 作業完了時 | 予定を実績に更新 + 看板更新 + Slack 報告 |
+
+## 前提
+
+- Claude Code に MCP `google-calendar` が allow 済み
+- カレンダー名の命名体系がグローバル CLAUDE.md に従っている
+
+## 非機能
+
+- MCP が利用不可な端末では **静かに skip**（このスキルはガイドラインなので、実呼び出しはセッション側の責務）
+- 同じ作業枠を二重登録しない（`description` に link を入れることで重複検出可能）

--- a/.claude/skills/notify-slack/SKILL.md
+++ b/.claude/skills/notify-slack/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: notify-slack
+description: Slack chat.postMessage を叩く共通シェル関数。~/.config/patrol/secrets.sh の SLACK_BOT_TOKEN / SLACK_CHANNEL_ID を読んで投稿する。メンション付き通知はユーザーの U08RPS2BLUD を文字列に含める。
+---
+
+# notify-slack
+
+プロジェクト横断で使える Slack 通知関数の canonical 版。
+
+## 由来
+
+`agent-playbook/scripts/patrol-config.sh` の `notify_slack` を抽出・正規化したもの。今後、agent-playbook 側もここを参照する方向に寄せる。
+
+## 使い方（プロジェクトからの取得）
+
+```bash
+bash ~/mgmt-team/platform-standards/scripts/ps-fetch.sh \
+  catalog/skills/notify-slack \
+  --dest .claude/skills/notify-slack
+```
+
+取得後、シェルスクリプトから:
+
+```bash
+source .claude/skills/notify-slack/notify.sh
+notify_slack "<@U08RPS2BLUD> 作業開始" "$SLACK_CHANNEL_ID"
+```
+
+## 前提
+
+- `~/.config/patrol/secrets.sh` に `SLACK_BOT_TOKEN` を定義
+- 投稿先チャンネル ID は呼び出し時の第 2 引数、または環境変数 `SLACK_CHANNEL_ID`
+- メンション運用はグローバル指示に従い `<@U08RPS2BLUD>` を本文に含める
+
+## 非機能
+
+- BOT_TOKEN が無ければ**静かに終了**（return 0）。CI や secrets 未設定の端末で落ちない
+- curl 失敗時も `|| true` で握りつぶす。通知は副次的処理のため本体を止めない
+- POST body は python3 で JSON シリアライズして改行・特殊文字を安全に扱う

--- a/.claude/skills/notify-slack/notify.sh
+++ b/.claude/skills/notify-slack/notify.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# notify-slack canonical 版
+#   - chat.postMessage を叩く
+#   - ~/.config/patrol/secrets.sh の SLACK_BOT_TOKEN / SLACK_CHANNEL_ID を利用
+#   - BOT_TOKEN 未設定なら静かに return（CI や secrets 未配備で落ちない）
+#
+# Usage:
+#   source notify.sh
+#   notify_slack "<@U08RPS2BLUD> 作業開始" "$SLACK_CHANNEL_ID"
+
+notify_slack() {
+  local text="$1"
+  local channel="${2:-}"
+  local secrets_file="$HOME/.config/patrol/secrets.sh"
+  [[ -f "$secrets_file" ]] && source "$secrets_file"
+  [[ -z "${SLACK_BOT_TOKEN:-}" ]] && return 0
+  local target="${channel:-${SLACK_CHANNEL_ID:-}}"
+  [[ -z "$target" ]] && return 0
+  local payload
+  payload="$(python3 -c "import json,sys; print(json.dumps({'channel': sys.argv[1], 'text': sys.argv[2]}))" "$target" "$text")"
+  curl -s -X POST "https://slack.com/api/chat.postMessage" \
+    -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+    -H 'Content-type: application/json' \
+    --data "$payload" \
+    >/dev/null 2>&1 || true
+}

--- a/.claude/skills/task-board-sync/SKILL.md
+++ b/.claude/skills/task-board-sync/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: task-board-sync
+description: Obsidian Vault のタスク看板（タスク.md, kanban-plugin 形式）にプロジェクトレーンを維持し、GitHub Issue/PR の状態と整合させる。SessionStart や重要イベント時に主体的に呼び出され、ユーザーが看板を見たときに常に最新の状況が把握できる状態を保つ。
+---
+
+# task-board-sync
+
+プロジェクトの状況を Obsidian タスク看板に常に反映させ続けるスキル。
+
+## 目的
+
+ユーザーが Obsidian の `タスク.md` を見たときに、各プロジェクトの状況が一目で把握できる状態を維持する。エージェント側が主体的に看板を更新し、看板の鮮度を保つ責務を持つ。
+
+## トリガー
+
+このスキルは **エージェントが主体的に** 起動する：
+
+| タイミング | 動作 |
+|---|---|
+| SessionStart | 自プロジェクトのレーン状態を確認し、ズレていたら同期 |
+| GitHub の Issue/PR 状態が変化した直後（merge / close 等） | 該当カードを更新 |
+| ユーザーが `/task-board-sync` を明示的に叩いた | 全同期 |
+| 週次（金曜終業時など）| 完了カードを Done レーンへアーカイブ |
+
+## レーン規約
+
+**レーンヘッダ表記**: `## ## <lane-name>`（既存 Vault の流儀に従う）
+
+例:
+
+```
+## ## prj-django-project
+## ## oss-cmux
+```
+
+レーン名 = グローバル CLAUDE.md の命名体系に準拠：
+
+- `prj-django-project`, `prj-vue-chat`（個人プロジェクト）
+- `oss-cmux`, `oss-projen`（OSS 活動）
+- `role-shindan`（資格・ロール）
+- `study-data`（学習）
+- `life-housing`, `fin-budget`（生活・財務）
+
+各プロジェクトは **1 レーン** を持つ。レーンが無ければ `task-board-sync` が新設する。
+
+**挿入位置**: 既存の `## ## ...` プロジェクトレーン群の **末尾**（つまり次に来る `## # Daily` などの状態レーンの直前）。新規プロジェクトレーンが既存のプロジェクト群と固まって表示されるよう揃える。
+
+## カードフォーマット（canonical）
+
+詳細は `card-template.md`。既存の和文タブインデント運用に `link:` `done-when:` を追加した形：
+
+```
+- [ ] <タイトル>
+	
+	@{YYYY-MM-DD}
+	予定：2h / 実績：h
+	link: <GitHub Issue/PR URL or "no-git">
+	done-when: <完了条件 1 行>
+	#<lane-name>
+```
+
+- インデントはタブ
+- `link: no-git` のカードは GitHub に紐付かない手動タスク。タグに `#manual-task` を併記する
+- `done-when:` の条件が満たされたら、エージェントは看板上で `[ ]` → `[x]` に更新する
+
+## 同期ルール
+
+1. **GitHub に存在し、看板に無い**: 新規カードとして追加
+2. **GitHub で close / merge 済み**: 看板側を完了状態に
+3. **GitHub に無く、看板に手動タスクとして存在**: そのまま残す（`#manual-task` ラベルで明示）
+4. **完了から 7 日経過したカード**: Done レーンへアーカイブ（週次）
+
+## 端末差の吸収
+
+Vault のパスは端末ごとに異なる。環境変数で指定：
+
+| 変数 | 例 |
+|---|---|
+| `OBSIDIAN_VAULT_PATH` | 私用: `~/Library/Mobile Documents/iCloud~md~obsidian/Documents/obsidian-private`<br>業務: `~/Desktop/work` |
+| `OBSIDIAN_BOARD_FILE` | デフォルト `タスク.md` |
+
+設定ファイル: `~/.config/obsidian-task-sync/env.sh`（端末ごとに 1 回作成）。例:
+
+```bash
+# ~/.config/obsidian-task-sync/env.sh
+export OBSIDIAN_VAULT_PATH="$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents/obsidian-private"
+export OBSIDIAN_BOARD_FILE="タスク.md"
+```
+
+## 使い方
+
+```bash
+source .claude/skills/task-board-sync/sync.sh
+task_board_sync_lane prj-django-project    # 自プロジェクトのレーンを同期
+task_board_sync_archive_done               # 完了 7 日経過カードをアーカイブ
+```
+
+## 前提
+
+- 看板は kanban-plugin 形式（`kanban-plugin: board` frontmatter 必須）
+- インデントはタブ文字（kanban-plugin 仕様）
+- `gh` CLI が認証済み（`gh auth status` が ok）
+
+## 非機能
+
+- `OBSIDIAN_VAULT_PATH` 未設定 / Vault 不在の端末では **静かに終了**（return 0）
+- 看板書き換えはアトミック（一時ファイル → mv）
+- 看板の frontmatter は破壊しない

--- a/.claude/skills/task-board-sync/card-template.md
+++ b/.claude/skills/task-board-sync/card-template.md
@@ -1,0 +1,74 @@
+# カードフォーマット（canonical）
+
+タスク看板（kanban-plugin 形式）に登録するカードの正本テンプレート。
+既存の和文タブインデント運用を尊重しつつ、エージェントが必要とする `link:` / `done-when:` を追加する形。
+
+## 基本形
+
+```
+- [ ] <タイトル>
+	
+	@{YYYY-MM-DD}
+	予定：<例: 2h> / 実績：h
+	link: <GitHub Issue/PR URL or "no-git">
+	done-when: <完了条件 1 行>
+	#<lane-name>
+```
+
+> インデントは **タブ文字**（kanban-plugin 仕様）。スペースに変換しないこと。
+> カード本文（`- [ ]` の行）の次は **空行を 1 行**置く（既存運用に倣う）。
+
+## フィールド定義
+
+| フィールド | 必須 | 内容 |
+|---|---|---|
+| タイトル | ◯ | 一行サマリ。動詞＋目的語推奨（例: "psctl bootstrap を実装する"）|
+| `@{YYYY-MM-DD}` | ◯ | 看板の日付（kanban-plugin の date 形式）|
+| `予定：Xh / 実績：h` | ◯ | 見積工数 / 実績工数の和文表記。実績は完了時に埋める |
+| `link:` | ◯ | GitHub Issue/PR の URL。手動タスクの場合は `no-git` |
+| `done-when:` | ◯ | 完了条件 1 行 |
+| `#<lane>` | ◯ | プロジェクトレーン名のタグ（`#prj-xxx` など）|
+
+## カード例
+
+GitHub Issue 紐付き:
+
+```
+- [ ] psctl bootstrap を実装する
+	
+	@{2026-05-01}
+	予定：2h / 実績：h
+	link: https://github.com/ohikouta/platform-standards/issues/12
+	done-when: PR merge ＋ Slack で完了報告
+	#prj-platform-standards
+```
+
+GitHub 紐付け無し（手動タスク）:
+
+```
+- [ ] 議事録テンプレを作る
+	
+	@{2026-05-02}
+	予定：30m / 実績：h
+	link: no-git
+	done-when: テンプレを wiki に登録、Slack で共有
+	#prj-django-project #manual-task
+```
+
+`#manual-task` タグを併記することで、看板上で手動タスクが視覚的に区別できる。
+
+## 完了条件（done-when）の書き方
+
+「何をもって完了とするか」を 1 文で表す。曖昧さを排する。
+
+良い例:
+- `done-when: PR が main に merge され、Slack に完了報告投稿`
+- `done-when: Calendar に作業枠が反映され、当日終業まで実施`
+
+悪い例:
+- `done-when: 終わったら` ← 何が「終わり」か不明
+- `done-when: 様子を見る` ← 完了条件になっていない
+
+## アーカイブ
+
+Done レーンで完了から 7 日経過したカードは、月次でアーカイブファイル（`タスク-archive-YYYY-MM.md`）へ退避する。看板本体は軽く保つ。

--- a/.claude/skills/task-board-sync/sync.sh
+++ b/.claude/skills/task-board-sync/sync.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+# task-board-sync — Obsidian タスク看板（kanban-plugin）と GitHub 状態を同期する。
+#
+# 使い方（直接実行）:
+#   task-board-sync                       # cwd の .claude/project.json から lane を取る
+#   task-board-sync prj-django-project    # 明示
+#   task-board-sync --archive [days]      # Done レーンの古いカードをアーカイブ
+#
+# Source して関数を使う形:
+#   source .claude/skills/task-board-sync/sync.sh
+#   task_board_sync_lane prj-django-project
+#   task_board_sync_archive_done
+#
+# 環境変数（明示で指定したいときだけ）:
+#   OBSIDIAN_VAULT_PATH   Vault のルート（未指定なら自動検出）
+#   OBSIDIAN_BOARD_FILE   看板ファイル名（既定: タスク.md）
+
+set -uo pipefail
+
+# 設定ファイルがあれば読む（明示優先）
+_TBSYNC_ENV="${TBSYNC_ENV:-$HOME/.config/obsidian-task-sync/env.sh}"
+[[ -f "$_TBSYNC_ENV" ]] && source "$_TBSYNC_ENV"
+
+OBSIDIAN_BOARD_FILE="${OBSIDIAN_BOARD_FILE:-タスク.md}"
+
+# _tbsync_autodetect_vault
+#   OBSIDIAN_VAULT_PATH が未設定なら、定石の場所を探して 1 つだけ見つかれば採用。
+#   複数見つかれば警告し失敗（明示指定を促す）。
+_tbsync_autodetect_vault() {
+  if [[ -n "${OBSIDIAN_VAULT_PATH:-}" ]]; then
+    return 0
+  fi
+  local candidates=()
+  local glob_root="$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents"
+  if [[ -d "$glob_root" ]]; then
+    while IFS= read -r d; do
+      [[ -f "$d/$OBSIDIAN_BOARD_FILE" ]] && candidates+=("$d")
+    done < <(find "$glob_root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null)
+  fi
+  if [[ -d "$HOME/Desktop/work" && -f "$HOME/Desktop/work/$OBSIDIAN_BOARD_FILE" ]]; then
+    candidates+=("$HOME/Desktop/work")
+  fi
+  if [[ ${#candidates[@]} -eq 1 ]]; then
+    OBSIDIAN_VAULT_PATH="${candidates[0]}"
+    export OBSIDIAN_VAULT_PATH
+    return 0
+  elif [[ ${#candidates[@]} -gt 1 ]]; then
+    {
+      echo "task-board-sync: multiple Vault candidates found — set OBSIDIAN_VAULT_PATH explicitly:"
+      for c in "${candidates[@]}"; do echo "    $c"; done
+    } >&2
+    return 1
+  fi
+  return 1
+}
+
+task_board_path() {
+  _tbsync_autodetect_vault || return 1
+  local board="$OBSIDIAN_VAULT_PATH/$OBSIDIAN_BOARD_FILE"
+  [[ -f "$board" ]] || return 1
+  printf '%s' "$board"
+}
+
+task_board_available() {
+  task_board_path >/dev/null 2>&1
+}
+
+# _tbsync_lane_from_project_json
+#   現在のディレクトリ（または上方向）に .claude/project.json があれば lane を取り出す。
+_tbsync_lane_from_project_json() {
+  local d="$PWD"
+  while [[ "$d" != "/" ]]; do
+    local f="$d/.claude/project.json"
+    if [[ -f "$f" ]]; then
+      python3 - "$f" <<'PY' 2>/dev/null
+import json, sys, pathlib
+data = json.loads(pathlib.Path(sys.argv[1]).read_text() or "{}")
+lane = data.get("lane", "")
+if lane: print(lane)
+PY
+      return 0
+    fi
+    d="$(dirname "$d")"
+  done
+}
+
+# task_board_sync_lane <lane>
+#   指定レーンを GitHub の Issue/PR と同期する。レーンが無ければ作る。手動カード（link: no-git）は残す。
+task_board_sync_lane() {
+  local lane="${1:-}"
+  if [[ -z "$lane" ]]; then
+    echo "task-board-sync: lane name required" >&2
+    return 2
+  fi
+  if ! task_board_available; then
+    echo "task-board-sync: Vault not found (set OBSIDIAN_VAULT_PATH or place vault under iCloud Obsidian / ~/Desktop/work) — skip" >&2
+    return 0
+  fi
+  local board; board="$(task_board_path)"
+
+  local gh_json
+  if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    gh_json="$(_tbsync_collect_github 2>/dev/null || printf '%s' '{"items":[]}')"
+  else
+    gh_json='{"items":[]}'
+  fi
+
+  python3 - "$board" "$lane" "$gh_json" <<'PY'
+import sys, re, json, pathlib, datetime
+
+board_path = pathlib.Path(sys.argv[1])
+lane       = sys.argv[2]
+gh         = json.loads(sys.argv[3])
+gh_items   = gh.get("items", [])
+
+text = board_path.read_text()
+
+fm_match = re.match(r'^---\s*\n(.*?)\n---\s*\n', text, re.DOTALL)
+if not fm_match or "kanban-plugin" not in fm_match.group(1):
+    print(f"task-board-sync: {board_path.name} に kanban-plugin frontmatter 無し — skip",
+          file=sys.stderr)
+    sys.exit(0)
+
+lane_re = re.compile(r'^(##\s.*)$', re.MULTILINE)
+
+def parse_sections(t):
+    splits  = list(lane_re.finditer(t))
+    out     = []
+    for i, m in enumerate(splits):
+        head = m.group(1)
+        body_start = m.end() + 1
+        body_end   = splits[i+1].start() if i+1 < len(splits) else len(t)
+        out.append([head, t[body_start:body_end], m.start(), body_end])
+    return out
+
+# Project lanes are written as "## ## <name>" to match the existing board's
+# convention (## ## SAP / ## ## SAA / ## ## real-chat 等). The "## " prefix
+# is required by kanban-plugin to recognize a lane; the second "## " is the
+# lane title style as used in this vault.
+target_header = f"## ## {lane}"
+
+sections = parse_sections(text)
+
+if not any(s[0] == target_header for s in sections):
+    # Find insertion point: directly after the last "## ## ..." section.
+    # Fallback: before the first "## # ..." (state lane like Daily/Done) or at end.
+    proj_idxs = [i for i,s in enumerate(sections) if s[0].startswith("## ## ")]
+    if proj_idxs:
+        insert_at = sections[proj_idxs[-1]][3]
+    else:
+        state_idxs = [i for i,s in enumerate(sections) if s[0].startswith("## # ")]
+        insert_at = sections[state_idxs[0]][2] if state_idxs else len(text)
+
+    # Normalize spacing around the insertion point so we don't create stacks of
+    # blank lines from prior runs.
+    before = text[:insert_at].rstrip("\n")
+    after  = text[insert_at:].lstrip("\n")
+    new_block = f"\n\n{target_header}\n\n\n"
+    text = before + new_block + after
+    board_path.write_text(text)
+    print(f"task-board-sync: created lane '{lane}' as '{target_header}'", file=sys.stderr)
+    sections = parse_sections(text)
+
+target_idx = next(i for i,s in enumerate(sections) if s[0] == target_header)
+lane_body  = sections[target_idx][1]
+
+card_re = re.compile(
+    r'(- \[(?P<state>[ x])\] (?P<title>[^\n]+)\n'
+    r'(?:[\t ]+[^\n]*\n)*?'
+    r'[\t ]+link:\s*(?P<link>\S+)[^\n]*\n'
+    r'(?:[\t ]+[^\n]*\n)*)',
+    re.MULTILINE)
+
+existing = {}
+for m in card_re.finditer(lane_body):
+    existing[m.group("link")] = {
+        "state": m.group("state"),
+        "title": m.group("title"),
+        "raw":   m.group(1),
+    }
+
+today = datetime.date.today().isoformat()
+
+def render_card(title, url, due, estimate, done_when, tags, state=" "):
+    title = title.strip()
+    return (
+        f"- [{state}] {title}\n"
+        f"\t\n"
+        f"\t@{{{due}}}\n"
+        f"\t予定：{estimate} / 実績：h\n"
+        f"\tlink: {url}\n"
+        f"\tdone-when: {done_when}\n"
+        f"\t{tags}\n"
+    )
+
+appended = []
+updated  = 0
+for it in gh_items:
+    url    = it["url"]
+    title  = it["title"]
+    closed = it["state"] in ("closed",) or it.get("merged") is True
+    if url in existing:
+        e = existing[url]
+        if closed and e["state"] == " ":
+            new_block = re.sub(r'^- \[ \]', '- [x]', e["raw"], count=1, flags=re.MULTILINE)
+            lane_body = lane_body.replace(e["raw"], new_block, 1)
+            updated += 1
+        elif not closed and e["state"] == "x":
+            new_block = re.sub(r'^- \[x\]', '- [ ]', e["raw"], count=1, flags=re.MULTILINE)
+            lane_body = lane_body.replace(e["raw"], new_block, 1)
+            updated += 1
+    else:
+        if closed:
+            continue
+        card = render_card(
+            title=title, url=url, due=today, estimate="-",
+            done_when="<未記入：完了条件を書くこと>",
+            tags=f"#{lane}", state=" ",
+        )
+        appended.append(card)
+
+if appended:
+    if not lane_body.endswith("\n"):
+        lane_body += "\n"
+    lane_body += "\n" + "\n".join(appended)
+
+sections[target_idx][1] = lane_body
+new_text = text[:sections[0][2]]
+for s in sections:
+    new_text += s[0] + "\n" + s[1]
+
+tmp = board_path.with_suffix(board_path.suffix + ".tmp")
+tmp.write_text(new_text)
+tmp.replace(board_path)
+
+print(f"task-board-sync: lane='{lane}' added={len(appended)} updated={updated} "
+      f"(github_items={len(gh_items)})", file=sys.stderr)
+PY
+}
+
+_tbsync_collect_github() {
+  local remote_url repo
+  remote_url="$(git config --get remote.origin.url 2>/dev/null || true)"
+  [[ -z "$remote_url" ]] && { echo '{"items":[]}'; return 0; }
+  if [[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/.]+) ]]; then
+    repo="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+  else
+    echo '{"items":[]}'; return 0
+  fi
+  python3 - "$repo" <<'PY'
+import json, subprocess, sys
+repo = sys.argv[1]
+def jq(args):
+    out = subprocess.run(["gh"] + args + ["--repo", repo], capture_output=True, text=True)
+    if out.returncode != 0: return []
+    return json.loads(out.stdout or "[]")
+issues = jq(["issue", "list", "--state", "all", "--limit", "100",
+             "--json", "number,title,state,url"])
+prs    = jq(["pr",    "list", "--state", "all", "--limit", "100",
+             "--json", "number,title,state,url,mergedAt"])
+items = []
+for i in issues:
+    items.append({"url": i["url"], "title": i["title"], "state": i["state"].lower()})
+for p in prs:
+    items.append({"url": p["url"], "title": p["title"],
+                  "state": p["state"].lower(), "merged": bool(p.get("mergedAt"))})
+print(json.dumps({"items": items}, ensure_ascii=False))
+PY
+}
+
+task_board_sync_archive_done() {
+  local days="${1:-7}"
+  if ! task_board_available; then return 0; fi
+  local board; board="$(task_board_path)"
+  python3 - "$board" "$days" <<'PY'
+import sys, re, pathlib, datetime
+board = pathlib.Path(sys.argv[1])
+days  = int(sys.argv[2])
+text  = board.read_text()
+lane_re = re.compile(r'^(##\s.*)$', re.MULTILINE)
+splits  = list(lane_re.finditer(text))
+sections = []
+for i, m in enumerate(splits):
+    head = m.group(1)
+    body_start = m.end() + 1
+    body_end   = splits[i+1].start() if i+1 < len(splits) else len(text)
+    sections.append([head, text[body_start:body_end], m.start(), body_end])
+done_idxs = [i for i,s in enumerate(sections) if s[0].strip().lower() in ("## done", "## 完了")]
+if not done_idxs:
+    print("task-board-sync: Done レーンが無い — skip", file=sys.stderr); sys.exit(0)
+done_idx  = done_idxs[0]
+done_body = sections[done_idx][1]
+threshold = datetime.date.today() - datetime.timedelta(days=days)
+card_re = re.compile(r'(- \[x\] [^\n]+\n(?:[\t ]+[^\n]*\n)*)', re.MULTILINE)
+date_re = re.compile(r'@\{(\d{4}-\d{2}-\d{2})\}')
+archived_cards = []
+remaining      = done_body
+for m in card_re.finditer(done_body):
+    block = m.group(1)
+    d = date_re.search(block)
+    if not d: continue
+    try: card_date = datetime.date.fromisoformat(d.group(1))
+    except ValueError: continue
+    if card_date <= threshold:
+        archived_cards.append(block)
+        remaining = remaining.replace(block, "", 1)
+if not archived_cards:
+    print("task-board-sync: archive 対象なし", file=sys.stderr); sys.exit(0)
+ym = datetime.date.today().strftime("%Y-%m")
+arch_path = board.parent / f"タスク-archive-{ym}.md"
+existing = arch_path.read_text() if arch_path.exists() else f"# タスクアーカイブ {ym}\n\n"
+arch_path.write_text(existing + "\n".join(archived_cards) + "\n")
+sections[done_idx][1] = remaining
+new_text = text[:sections[0][2]]
+for s in sections:
+    new_text += s[0] + "\n" + s[1]
+tmp = board.with_suffix(board.suffix + ".tmp")
+tmp.write_text(new_text)
+tmp.replace(board)
+print(f"task-board-sync: archived {len(archived_cards)} cards → {arch_path.name}",
+      file=sys.stderr)
+PY
+}
+
+# 直接実行された場合のエントリポイント
+if [[ "${BASH_SOURCE[0]}" == "${0:-}" ]]; then
+  case "${1:-}" in
+    --archive)
+      shift
+      task_board_sync_archive_done "${1:-7}"
+      ;;
+    -h|--help)
+      cat <<'EOF'
+task-board-sync — Obsidian タスク看板を GitHub 状態と同期
+
+USAGE
+  task-board-sync [<lane>]            sync the given lane (or .claude/project.json's lane)
+  task-board-sync --archive [days]    archive Done cards older than `days` (default 7)
+  task-board-sync --help              show this help
+
+ENV
+  OBSIDIAN_VAULT_PATH   override vault auto-detect
+  OBSIDIAN_BOARD_FILE   override board filename (default: タスク.md)
+EOF
+      ;;
+    *)
+      lane="${1:-}"
+      if [[ -z "$lane" ]]; then
+        lane="$(_tbsync_lane_from_project_json)" || true
+      fi
+      if [[ -z "$lane" ]]; then
+        echo "task-board-sync: lane not specified and .claude/project.json not found" >&2
+        echo "  hint: place {\"lane\": \"prj-xxx\"} in .claude/project.json, or pass it as argument." >&2
+        exit 2
+      fi
+      task_board_sync_lane "$lane"
+      ;;
+  esac
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,24 @@
+#!/bin/sh
+# pre-push-protect-main — main への直接 push を拒否する
+#
+# 設置手順（プロジェクト側）:
+#   bash ~/mgmt-team/platform-standards/scripts/ps-fetch.sh \
+#     catalog/hooks/pre-push-protect-main --dest .githooks
+#   chmod +x .githooks/pre-push
+#   git config core.hooksPath .githooks
+
+remote_name="$1"
+remote_url="$2"
+
+while read local_ref local_sha remote_ref remote_sha
+do
+  case "$remote_ref" in
+    refs/heads/main)
+      echo "Direct push to main is blocked in this repository."
+      echo "Use a feature branch and open a pull request instead."
+      exit 1
+      ;;
+  esac
+done
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ src/staticfiles/
 
 # Playwright MCP artifacts
 .playwright-mcp/
+
+# claude local-only project notes
+CLAUDE.local.md
+
+# claude local-only settings (per-developer MCP/IDE)
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+このファイルは Claude Code（claude.ai/code）がこのリポジトリで作業する際に読むプロジェクトレベルの指示書。
+平時はこの 1 ファイル＋ `~/.claude/CLAUDE.md`（個人グローバル）の 2 階層で運用する。
+
+> **このひな形は `platform-standards/catalog/claude-md/project-generic.md` の canonical 配布物。**
+> このファイルはプロジェクト側で書き換えない（ReadOnly 運用）。プロジェクト固有のメモは隣に `CLAUDE.local.md` 等のローカル拡張ファイルを作って分離すること。
+
+## このプロジェクトの位置づけ
+
+<!-- TODO: プロジェクトの 1 段落サマリ。何のための repo で、誰が使うかを書く -->
+- **目的**: <!-- e.g. 社内向け××API。月次集計を Slack に流す -->
+- **オーナー**: <!-- e.g. @ohikouta -->
+- **対応 Slack チャンネル**: <!-- e.g. #prj-xxx（~/.claude/CLAUDE.md の命名体系に従う） -->
+- **対応 Google Calendar**: <!-- e.g. prj-xxx -->
+
+## 共通規約（platform-standards 由来）
+
+このプロジェクトは `platform-standards.lock.json` で導入物を管理している。導入状況は `psctl status` で確認できる。
+
+### Slack 通知
+
+`<@U08RPS2BLUD>` メンション付きで Slack に投稿するときは、共通スキル `notify-slack` を使う：
+
+```bash
+psctl fetch catalog/skills/notify-slack --dest .claude/skills/notify-slack    # 未導入なら 1 回だけ
+source .claude/skills/notify-slack/notify.sh
+notify_slack "<@U08RPS2BLUD> 作業開始" "$SLACK_CHANNEL_ID"
+```
+
+`SLACK_BOT_TOKEN` は `~/.config/patrol/secrets.sh` から自動で読まれる。`SLACK_CHANNEL_ID` は呼び出し時に明示的に渡すか環境変数で指定する。
+
+### Git / GitHub 運用
+
+`platform-standards/catalog/guidelines/git-workflow.md` の規約に従う（branch 命名・commit 規約・PR 運用）。
+ローカルに canonical を置く場合は：
+
+```bash
+psctl fetch catalog/guidelines/git-workflow.md --dest docs/standards/git-workflow.md
+```
+
+要点だけ抜粋：
+
+- `main` への直接 push は禁止。`pre-push-protect-main` Hook で reject される（後述）。
+- branch 名は `<type>/<topic>` の kebab-case（`feat/`, `fix/`, `docs/`, `chore/`, `refactor/`, `security/`）。
+- commit メッセージは Conventional Commits 風。`<type>(<scope>): <subject>`。
+
+### main 保護
+
+clone 後に 1 回だけ：
+
+```bash
+psctl fetch catalog/hooks/pre-push-protect-main --dest .githooks
+chmod +x .githooks/pre-push
+git config core.hooksPath .githooks
+```
+
+## 進捗管理（Slack / Calendar / Obsidian）
+
+`~/.claude/CLAUDE.md` のグローバル指示に従う：
+
+- **作業開始時**: 当日の作業枠を対応カレンダーに入れる（`gcal-event-register` skill 参照）。
+- **ミッション・マイルストーン**: 達成予定日をカレンダーに登録する。
+- **完了時**: 予定を実績として更新し、対応 Slack チャンネルに進捗を報告する（`notify-slack` skill）。
+- セッション単位ではなく、計画に対する成果を報告する。
+- **タスク看板**: Obsidian の `タスク.md` に自プロジェクトのレーンを 1 つ持ち、`task-board-sync` skill が GitHub Issue/PR と整合させる。
+  - カードフォーマット: `task-board-sync/card-template.md` 参照
+  - 起動: SessionStart / 重要イベント時にエージェントが主体的に呼び出す
+
+## Project-specific notes
+
+> 以降は各プロジェクトで自由に追記する領域。共通規約セクションは触らない。
+
+<!-- TODO:
+- セットアップ手順（依存・初期化スクリプト）
+- 開発・テスト・デプロイの代表コマンド
+- アーキテクチャ概略 / 触ってはいけないファイル
+- 外部サービスとの結線（DB, 外部 API, etc.）
+-->

--- a/docs/standards/git-workflow.md
+++ b/docs/standards/git-workflow.md
@@ -1,0 +1,79 @@
+# Git / GitHub ワークフロー（共通規約）
+
+このドキュメントは `platform-standards/catalog/guidelines/git-workflow.md` の canonical 配布物。
+各プロジェクトはこの規約に従う前提で、CLAUDE.md ひな形（`catalog/claude-md/project-generic.md`）から参照される。
+
+## 基本方針
+
+- **GitHub の Issue が正式なタスク単位**、Pull Request が正式な実装・レビュー単位、リポジトリ履歴が永続的な実行記録。
+- **GitHub 操作は可能な限り `gh` CLI を使う**。`gh` で完結しない場合 / ビジュアルレビューが必要な場合のみ Web UI を併用する。
+- **`main` への直接 push は禁止**。feature branch → PR → merge の順を厳守する。
+
+## ブランチ規約
+
+ブランチ名は `<type>/<topic>` の kebab-case。
+
+| type | 用途 |
+|---|---|
+| `feat/` | 機能追加 |
+| `fix/` | バグ修正 |
+| `docs/` | ドキュメントのみの変更 |
+| `chore/` | ビルド・依存・雑務（標準化適用も含む）|
+| `refactor/` | 振る舞い不変のコード整理 |
+| `security/` | 脆弱性対応 |
+
+例: `feat/notify-slack-mention`, `chore/adopt-platform-standards`
+
+## コミットメッセージ
+
+Conventional Commits 風: `<type>(<scope>): <subject>`
+
+- `<type>` はブランチと同じ語彙
+- `<scope>` は影響範囲（モジュール名・ディレクトリ名など）。省略可
+- `<subject>` は **何をしたか** ではなく **なぜしたか** を意識する 1〜2 文
+
+例:
+
+- `feat(notify-slack): メンション必須化で誤投稿を防止`
+- `chore(catalog): bootstrap 後の sha 不一致を修正`
+
+## Pull Request 運用
+
+1. `main` から branch を切る
+2. branch 上で変更し、コミットを重ねる
+3. push して `gh pr create` で PR を作る
+4. レビュー → merge 後に `main` が更新される
+5. ローカル `main` は `git pull --ff-only` で同期する
+
+PR スコープはレビュー可能な範囲（おおむね 400 行未満を目安）に収める。大きな変更は段階的 PR に分割する。
+
+## main 保護
+
+GitHub の branch protection が使えない private repo では、ローカル Hook で代替する。
+
+```bash
+psctl fetch catalog/hooks/pre-push-protect-main      # 未導入なら 1 回だけ
+git config core.hooksPath .githooks
+```
+
+`pre-push-protect-main` は `main` への直接 push を git 側で reject する。`--no-verify` で迂回しないこと（迂回すると保護が無効化される）。
+
+## 認証
+
+```bash
+gh auth status      # トークン状態を確認
+gh auth login -h github.com   # 切れていたら再ログイン
+```
+
+リモート操作の前に `gh auth status` を一度確認するのを習慣にする。
+
+## Obsidian / 進捗管理との関係
+
+- **GitHub に書くもの**: 正式な実装単位（Issue / PR）、永続コラボレーション記録
+- **Obsidian / カレンダー / Slack に書くもの**: 補助コンテキスト、下書き、意思決定ログ、進捗報告
+
+両者でタスク状態が食い違っているときは、操作前に最新の意図を確認すること。
+
+## 出典
+
+このガイドラインは `agent-playbook/docs/github-workflow.md` および `repository-guardrails.md` を統合・改訂したもの。canonical はこのファイル。

--- a/platform-standards.lock.json
+++ b/platform-standards.lock.json
@@ -1,0 +1,41 @@
+{
+  "version": 1,
+  "standards": [
+    {
+      "source": "catalog/claude-md/project-generic.md",
+      "dest": "CLAUDE.md",
+      "fetched_at": "2026-05-02T07:42:59Z",
+      "source_sha": "aaae7028bea197737d42ea9a2a272b565fb287f0d66acf628f9a5d1ead984ab3"
+    },
+    {
+      "source": "catalog/guidelines/git-workflow.md",
+      "dest": "docs/standards/git-workflow.md",
+      "fetched_at": "2026-05-01T00:14:11Z",
+      "source_sha": "8d0e3036b6b75767d85fe89be9fbcef79d4ba41cf1060d1094b41f9a240e3827"
+    },
+    {
+      "source": "catalog/hooks/pre-push-protect-main",
+      "dest": ".githooks/pre-push",
+      "fetched_at": "2026-04-30T23:19:14Z",
+      "source_sha": "a4a03eda5233d2c8b2e4a824e62a37c0e13c4ec8e29a2803b3368d38bfcc8c73"
+    },
+    {
+      "source": "catalog/skills/gcal-event-register",
+      "dest": ".claude/skills/gcal-event-register",
+      "fetched_at": "2026-05-01T00:14:10Z",
+      "source_sha": "c6e42461182bbba8c0ed3b9941cd02e03ab5210038c5d8aab882f69df2fb6690"
+    },
+    {
+      "source": "catalog/skills/notify-slack",
+      "dest": ".claude/skills/notify-slack",
+      "fetched_at": "2026-04-30T23:19:14Z",
+      "source_sha": "9593b950d5fd3d749d4fb43b7364711260226b928d83132eaae34aaaa3d8fa3d"
+    },
+    {
+      "source": "catalog/skills/task-board-sync",
+      "dest": ".claude/skills/task-board-sync",
+      "fetched_at": "2026-05-02T07:43:01Z",
+      "source_sha": "e238efba3fd2bbb0b4c76f082fe83ab317aabc9fcf5941d7398e4d57a004cdc1"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- platform-standards (psctl) で 6 件の standards を bootstrap
- pre-push hook で main 直 push を拒否、SessionStart で `psctl status --brief --if-outdated` と `task-board-sync` を自動実行
- skills: notify-slack / gcal-event-register / task-board-sync を `.claude/skills/` 配下に配置
- CLAUDE.md は project-generic ひな形、プロジェクト固有メモは `CLAUDE.local.md`（gitignore）に分離
- lane `prj-django-project` を `.claude/project.json` に登録
- `.gitignore` に `CLAUDE.local.md` と `.claude/settings.local.json` を追加

## Test plan
- [ ] `psctl status` がすべて up-to-date を表示
- [ ] `git config core.hooksPath` が `.githooks` を指している
- [ ] main へ直接 push しようとすると pre-push hook が reject する
- [ ] 次回 Claude Code セッションで SessionStart hook が実行される
- [ ] Phase D 着手時に Issue #6 が `prj-django-project` レーンへ反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)